### PR TITLE
Namespaced NumbersAndWords

### DIFF
--- a/lib/locales/plurals.rb
+++ b/lib/locales/plurals.rb
@@ -1,22 +1,33 @@
-ru_rule = lambda do |count|
-  case count
-  when Integer
-    case
-    when 1 == count
-      :one
-    when (2..4).include?(count)
-      :few
-    else
-      :many
+module NumbersAndWords
+  module Locales
+    module Plurals
+    
+      RU = lambda do |count|
+        case count
+        when Integer
+          case
+          when 1 == count
+            :one
+          when (2..4).include?(count)
+            :few
+          else
+            :many
+          end
+        else
+          :other
+        end
+      end
+
+      EN = lambda do |count| 
+        1 == count ? :one : :other
+      end
+      
     end
-  else
-    :other
   end
 end
 
-en_rule = lambda{|count| 1 == count ? :one : :other}
-
 {
-  :ru => {:i18n => {:plural => {:rule => ru_rule}}},
-  :en => {:i18n => {:plural => {:rule => en_rule}}}
+  :ru => { :i18n => { :plural => { :rule => NumbersAndWords::Locales::Plurals::RU }}},
+  :en => { :i18n => { :plural => { :rule => NumbersAndWords::Locales::Plurals::EN }}}
 }
+

--- a/lib/numbers_and_words.rb
+++ b/lib/numbers_and_words.rb
@@ -11,16 +11,18 @@ require 'numbers_and_words/figures_array'
 require 'numbers_and_words/core_ext/integer'
 require 'numbers_and_words/core_ext/array'
 
-module I18nInitialization
-  extend self
+module NumbersAndWords
+  module I18nInitialization
+    extend self
 
-  def init
-    I18n.load_path << locale_files
-  end
+    def init
+      I18n.load_path << locale_files
+    end
 
-  def locale_files
-    Dir[File.join(File.dirname(__FILE__), 'locales', '**/*')]
+    def locale_files
+      Dir[File.join(File.dirname(__FILE__), 'locales', '**/*')]
+    end
   end
 end
 
-I18nInitialization.init
+NumbersAndWords::I18nInitialization.init

--- a/lib/numbers_and_words/array_additions/helpers.rb
+++ b/lib/numbers_and_words/array_additions/helpers.rb
@@ -1,48 +1,51 @@
-module ArrayAdditions
-  module Helpers
-    THOUSAND_CAPACITY = 1
+module NumbersAndWords
+  module ArrayAdditions
+    module Helpers
+      THOUSAND_CAPACITY = 1
 
-    def capacity_count
-      count = (self.length.to_f / 3).ceil
-      1 == count ? nil : count
-    end
+      def capacity_count
+        count = (self.length.to_f / 3).ceil
+        1 == count ? nil : count
+      end
 
-    def figures_array_in_capacity capacity
-      self[capacity * 3, 3]
-    end
+      def figures_array_in_capacity capacity
+        self[capacity * 3, 3]
+      end
 
-    def number_in_capacity capacity
-      figures_array_in_capacity(capacity).reverse.join.to_i
-    end
+      def number_in_capacity capacity
+        figures_array_in_capacity(capacity).reverse.join.to_i
+      end
 
-    def number_for_gender capacity
-      figures = figures_array_in_capacity(capacity)
-      teens = figures.teens
-      teens ? teens.join.to_i : figures.first
-    end
+      def number_for_gender capacity
+        figures = figures_array_in_capacity(capacity)
+        teens = figures.teens
+        teens ? teens.join.to_i : figures.first
+      end
 
-    def is_a_thousand_capacity? capacity
-      THOUSAND_CAPACITY == capacity
-    end
+      def is_a_thousand_capacity? capacity
+        THOUSAND_CAPACITY == capacity
+      end
 
-    def ones
-      self[0] if 0 < self[0].to_i
-    end
+      def ones
+        self[0] if 0 < self[0].to_i
+      end
 
-    def teens
-      tens_with_ones if 1 == tens
-    end
+      def teens
+        tens_with_ones if 1 == tens
+      end
 
-    def tens
-      self[1] if self[1] and 0 < self[1].to_i
-    end
+      def tens
+        self[1] if self[1] and 0 < self[1].to_i
+      end
 
-    def tens_with_ones
-      [ones, tens] if ones and tens
-    end
+      def tens_with_ones
+        [ones, tens] if ones and tens
+      end
 
-    def hundreds
-      self[2] if 0 < self[2].to_i
+      def hundreds
+        self[2] if 0 < self[2].to_i
+      end
     end
   end
 end
+

--- a/lib/numbers_and_words/array_additions/validations.rb
+++ b/lib/numbers_and_words/array_additions/validations.rb
@@ -1,7 +1,10 @@
-module ArrayAdditions
-  module Validations
-    def validate_figure_array!
+module NumbersAndWords
+  module ArrayAdditions
+    module Validations
+      def validate_figure_array!
 
+      end
     end
   end
 end
+

--- a/lib/numbers_and_words/core_ext/array.rb
+++ b/lib/numbers_and_words/core_ext/array.rb
@@ -4,6 +4,6 @@ class Array
   end
 
   def to_figures
-    FiguresArray.new self
+    NumbersAndWords::FiguresArray.new self
   end
 end

--- a/lib/numbers_and_words/core_ext/integer.rb
+++ b/lib/numbers_and_words/core_ext/integer.rb
@@ -1,6 +1,7 @@
 class Integer
+
   def to_words
-    to_figures_array.to_words Strategies::Base.factory
+    to_figures_array.to_words NumbersAndWords::Strategies::Base.factory
   end
 
   private
@@ -8,4 +9,5 @@ class Integer
   def to_figures_array
     to_s.split(//).map(&:to_i).to_figures
   end
+
 end

--- a/lib/numbers_and_words/figures_array.rb
+++ b/lib/numbers_and_words/figures_array.rb
@@ -1,13 +1,16 @@
-class FiguresArray < Array
-  include ArrayAdditions::Helpers
-  include ArrayAdditions::Validations
+module NumbersAndWords
+  class FiguresArray < Array
+    include NumbersAndWords::ArrayAdditions::Helpers
+    include NumbersAndWords::ArrayAdditions::Validations
 
-  def to_words strategy, options = nil
-    validate_figure_array!
-    strategy.convert self
-  end
+    def to_words strategy, options = nil
+      validate_figure_array!
+      strategy.convert self
+    end
 
-  def reverse
-    super.to_figures
+    def reverse
+      super.to_figures
+    end
   end
 end
+

--- a/lib/numbers_and_words/strategies/base.rb
+++ b/lib/numbers_and_words/strategies/base.rb
@@ -1,10 +1,11 @@
-module Strategies
-  class Base
-    attr_accessor :figures, :words
+module NumbersAndWords
+  module Strategies
+    class Base
+      attr_accessor :figures, :words
 
-    def self.factory
-      "Strategies::#{I18n.locale.to_s.titleize}".constantize.new
+      def self.factory
+        "NumbersAndWords::Strategies::#{I18n.locale.to_s.titleize}".constantize.new
+      end
     end
   end
 end
-

--- a/lib/numbers_and_words/strategies/en.rb
+++ b/lib/numbers_and_words/strategies/en.rb
@@ -1,69 +1,72 @@
-module Strategies
-  class En < Base
-    include TranslationsHelpers::En
+module NumbersAndWords
+  module Strategies
+    class En < Base
+      include NumbersAndWords::TranslationsHelpers::En
 
-    attr_accessor :figures_in_previous_capacity
+      attr_accessor :figures_in_previous_capacity
 
-    def convert figures
-      @figures = figures.reverse
+      def convert figures
+        @figures = figures.reverse
 
-      @words = strings
-      @words.empty? ? zero : @words.reverse.join(' ')
-    end
-
-    private
-
-    def strings
-      if figures.capacity_count
-        complex_to_words
-      elsif figures.hundreds
-        simple_hundreds_to_words
-      elsif figures.tens or figures.ones
-        simple_to_words
-      else
-        []
+        @words = strings
+        @words.empty? ? zero : @words.reverse.join(' ')
       end
-    end
 
-    def complex_to_words
-      words = []
-      figures.capacity_count.times do |capacity|
-        number_in_capacity_by_words = save_parent_figures do |parent_figures|
-          @figures = parent_figures.figures_array_in_capacity(capacity)
-          strings
-        end
+      private
 
-        unless number_in_capacity_by_words.empty?
-          words.push translation_megs(capacity) if 0 < capacity
-          words += number_in_capacity_by_words
+      def strings
+        if figures.capacity_count
+          complex_to_words
+        elsif figures.hundreds
+          simple_hundreds_to_words
+        elsif figures.tens or figures.ones
+          simple_to_words
+        else
+          []
         end
       end
-      words
-    end
 
-    def simple_hundreds_to_words
-      simple_to_words + [translation_hundreds(figures.hundreds)]
-    end
+      def complex_to_words
+        words = []
+        figures.capacity_count.times do |capacity|
+          number_in_capacity_by_words = save_parent_figures do |parent_figures|
+            @figures = parent_figures.figures_array_in_capacity(capacity)
+            strings
+          end
 
-    def simple_to_words
-      if figures.teens
-        [translation_teens(figures.ones)]
-      elsif figures.tens
-        figures.ones ?
-          [translation_tens_with_ones(figures.tens_with_ones)] :
-          [translation_tens(figures.tens)]
-      elsif figures.ones
-        [translation_ones(figures.ones)]
-      else
-        []
+          unless number_in_capacity_by_words.empty?
+            words.push translation_megs(capacity) if 0 < capacity
+            words += number_in_capacity_by_words
+          end
+        end
+        words
       end
-    end
 
-    def save_parent_figures
-      parent_figures = @figures
-      result = yield(parent_figures)
-      @figures = parent_figures
-      result
+      def simple_hundreds_to_words
+        simple_to_words + [translation_hundreds(figures.hundreds)]
+      end
+
+      def simple_to_words
+        if figures.teens
+          [translation_teens(figures.ones)]
+        elsif figures.tens
+          figures.ones ?
+            [translation_tens_with_ones(figures.tens_with_ones)] :
+            [translation_tens(figures.tens)]
+        elsif figures.ones
+          [translation_ones(figures.ones)]
+        else
+          []
+        end
+      end
+
+      def save_parent_figures
+        parent_figures = @figures
+        result = yield(parent_figures)
+        @figures = parent_figures
+        result
+      end
     end
   end
 end
+

--- a/lib/numbers_and_words/strategies/ru.rb
+++ b/lib/numbers_and_words/strategies/ru.rb
@@ -1,69 +1,72 @@
-module Strategies
-  class Ru < Base
-    include TranslationsHelpers::Ru
+module NumbersAndWords
+  module Strategies
+    class Ru < Base
+      include NumbersAndWords::TranslationsHelpers::Ru
 
-    def convert figures
-      @figures = figures.reverse
-      @words = strings
+      def convert figures
+        @figures = figures.reverse
+        @words = strings
 
-      @words.empty? ? zero : @words.reverse.join(' ')
-    end
-
-    private
-
-    def strings gender = :male
-      if figures.capacity_count
-        complex_to_words
-      elsif figures.hundreds
-        simple_hundreds_to_words gender
-      elsif figures.tens or figures.ones
-        simple_to_words gender
-      else
-        []
+        @words.empty? ? zero : @words.reverse.join(' ')
       end
-    end
 
-    def complex_to_words
-      words = []
-      figures.capacity_count.times do |capacity|
-        number_in_capacity_by_words = save_parent_figures do
-          @figures = figures.figures_array_in_capacity(capacity)
-          strings figures.is_a_thousand_capacity?(capacity) ? :female : :male
+      private
+
+      def strings gender = :male
+        if figures.capacity_count
+          complex_to_words
+        elsif figures.hundreds
+          simple_hundreds_to_words gender
+        elsif figures.tens or figures.ones
+          simple_to_words gender
+        else
+          []
         end
+      end
 
-        unless number_in_capacity_by_words.empty?
-          if 0 < capacity
-            words.push translation_megs(capacity, figures.number_for_gender(capacity))
+      def complex_to_words
+        words = []
+        figures.capacity_count.times do |capacity|
+          number_in_capacity_by_words = save_parent_figures do
+            @figures = figures.figures_array_in_capacity(capacity)
+            strings figures.is_a_thousand_capacity?(capacity) ? :female : :male
           end
-          words += number_in_capacity_by_words
+
+          unless number_in_capacity_by_words.empty?
+            if 0 < capacity
+              words.push translation_megs(capacity, figures.number_for_gender(capacity))
+            end
+            words += number_in_capacity_by_words
+          end
+        end
+        words
+      end
+
+      def simple_hundreds_to_words gender
+        simple_to_words(gender) + [translation_hundreds(figures.hundreds)]
+      end
+
+      def simple_to_words gender
+        if figures.teens
+          [translation_teens(figures.ones)]
+        elsif figures.tens
+          figures.ones ?
+            [translation_tens_with_ones(figures.tens_with_ones, gender)] :
+            [translation_tens(figures.tens)]
+        elsif figures.ones
+          [translation_ones(figures.ones, gender)]
+        else
+          []
         end
       end
-      words
-    end
 
-    def simple_hundreds_to_words gender
-      simple_to_words(gender) + [translation_hundreds(figures.hundreds)]
-    end
-
-    def simple_to_words gender
-      if figures.teens
-        [translation_teens(figures.ones)]
-      elsif figures.tens
-        figures.ones ?
-          [translation_tens_with_ones(figures.tens_with_ones, gender)] :
-          [translation_tens(figures.tens)]
-      elsif figures.ones
-        [translation_ones(figures.ones, gender)]
-      else
-        []
+      def save_parent_figures
+        parent_figures = @figures
+        result = yield
+        @figures = parent_figures
+        result
       end
-    end
-
-    def save_parent_figures
-      parent_figures = @figures
-      result = yield
-      @figures = parent_figures
-      result
     end
   end
 end
+

--- a/lib/numbers_and_words/translations_helpers/base.rb
+++ b/lib/numbers_and_words/translations_helpers/base.rb
@@ -1,9 +1,12 @@
-module TranslationsHelpers
-  module Base
-    I18N_NAMESPACE = :numbers
+module NumbersAndWords
+  module TranslationsHelpers
+    module Base
+      I18N_NAMESPACE = :numbers
 
-    def t attribute, options = {}
-      I18n.t attribute, options.merge(:scope => I18N_NAMESPACE)
+      def t attribute, options = {}
+        I18n.t attribute, options.merge(:scope => I18N_NAMESPACE)
+      end
     end
   end
 end
+

--- a/lib/numbers_and_words/translations_helpers/en.rb
+++ b/lib/numbers_and_words/translations_helpers/en.rb
@@ -1,37 +1,41 @@
-module TranslationsHelpers::En
-  include TranslationsHelpers::Base
+module NumbersAndWords
+  module TranslationsHelpers
+    module En
+      include NumbersAndWords::TranslationsHelpers::Base
 
-  private
+      private
 
-  def translation_megs capacity
-    t(:mega)[capacity]
-  end
+      def translation_megs capacity
+        t(:mega)[capacity]
+      end
 
-  def translation_teens number
-    t(:teens)[number]
-  end
+      def translation_teens number
+        t(:teens)[number]
+      end
 
-  def translation_tens number
-    t(:tens)[number]
-  end
+      def translation_tens number
+        t(:tens)[number]
+      end
 
-  def translation_ones number
-    t(:ones)[number]
-  end
+      def translation_ones number
+        t(:ones)[number]
+      end
 
-  def translation_tens_with_ones numbers
-    [translation_tens(numbers[1]), translation_ones(numbers[0])].join '-'
-  end
+      def translation_tens_with_ones numbers
+        [translation_tens(numbers[1]), translation_ones(numbers[0])].join '-'
+      end
 
-  def translation_union
-    t :union
-  end
+      def translation_union
+        t :union
+      end
 
-  def translation_hundreds number
-    [t(:ones)[number], t(:hundreds)].join ' '
-  end
+      def translation_hundreds number
+        [t(:ones)[number], t(:hundreds)].join ' '
+      end
 
-  def zero
-    t(:ones_male)[0]
+      def zero
+        t(:ones_male)[0]
+      end
+    end
   end
 end

--- a/lib/numbers_and_words/translations_helpers/ru.rb
+++ b/lib/numbers_and_words/translations_helpers/ru.rb
@@ -1,37 +1,41 @@
-module TranslationsHelpers::Ru
-  include TranslationsHelpers::Base
+module NumbersAndWords
+  module TranslationsHelpers
+    module Ru
+      include NumbersAndWords::TranslationsHelpers::Base
 
-  private
+      private
 
-  def translation_megs capacity, number
-    t translation_mega(capacity), :count => number
-  end
+      def translation_megs capacity, number
+        t translation_mega(capacity), :count => number
+      end
 
-  def translation_teens number
-    t(:teens)[number]
-  end
+      def translation_teens number
+        t(:teens)[number]
+      end
 
-  def translation_tens number
-    t(:tens)[number]
-  end
+      def translation_tens number
+        t(:tens)[number]
+      end
 
-  def translation_ones number, gender
-    t([:ones, gender].join('_'))[number]
-  end
+      def translation_ones number, gender
+        t([:ones, gender].join('_'))[number]
+      end
 
-  def translation_tens_with_ones numbers, gender
-    [translation_tens(numbers[1]), translation_ones(numbers[0], gender)].join ' '
-  end
+      def translation_tens_with_ones numbers, gender
+        [translation_tens(numbers[1]), translation_ones(numbers[0], gender)].join ' '
+      end
 
-  def translation_hundreds number
-    t(:hundreds)[number]
-  end
+      def translation_hundreds number
+        t(:hundreds)[number]
+      end
 
-  def translation_mega capacity
-    t(:mega)[capacity]
-  end
+      def translation_mega capacity
+        t(:mega)[capacity]
+      end
 
-  def zero
-    t(:ones_male)[0]
+      def zero
+        t(:ones_male)[0]
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,5 @@ $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'numbers_and_words'
 
 RSpec.configure do
-  include TranslationsHelpers::Base
+  include NumbersAndWords::TranslationsHelpers::Base
 end


### PR DESCRIPTION
There're quite a few things in the global namespace, who knows what they collide with :) Namespaced everything to NumbersAndWords. 

Small note: there're a couple of places where namespace were declared as `module Foo::Bar`, which is actually different from 

``` ruby
module Foo 
  module Bar
  end
end 
```

The first case requires the namespace to have already been declared elsewhere, which would break depending in which order the files are loaded.
