### PR TITLE
Add French language

### DIFF
--- a/lib/numbers_and_words/i18n/locales/numbers.fr.yml
+++ b/lib/numbers_and_words/i18n/locales/numbers.fr.yml
@@ -1,0 +1,43 @@
+fr:
+  numbers:
+    ones: [zéro, un, deux, trois, quatre, cinq, six, sept, huit, neuf]
+    teens: [dix, onze, douze, treize, quatorze, quinze, seize, dix-sept, dix-huit, dix-neuf]
+    tens: [zéro, dix, vingt, trente, quarante, cinquante, soixante, soixante-dix, quatre-vingt, quatre-vingt-dix]
+    mega: [ones, thousands, millions, billions, trillions, quadrillions, quintillion, sextillions, septillions, octillions, nonillions, decillions]
+    eighty: quatre-vingts
+    hundreds:
+      one: cent
+      many: cents
+    thousands:
+      one: mille
+      many: mille
+    millions:
+      one: million
+      many: millions
+    billions:
+      one: milliard
+      many: milliards
+    trillions:
+      one: billion
+      many: billions
+    quadrillions:
+      one: billiard
+      many: billiards
+    quintillions:
+      one: trillion
+      many: trillions
+    sextillions:
+      one: trilliard
+      many: trilliards
+    septillions:
+      one: quadrillion
+      many: quadrillions
+    octillions:
+      one: quadrilliard
+      many: quadrilliards
+    nonillions:
+      one: quintillion
+      many: quintillions
+    decillions:
+      one: quintilliard
+      many: quintilliards

--- a/lib/numbers_and_words/i18n/pluralization.rb
+++ b/lib/numbers_and_words/i18n/pluralization.rb
@@ -1,3 +1,4 @@
+require 'numbers_and_words/i18n/plurals/fr'
 require 'numbers_and_words/i18n/plurals/ru'
 require 'numbers_and_words/i18n/plurals/ua'
 

--- a/lib/numbers_and_words/i18n/plurals/fr.rb
+++ b/lib/numbers_and_words/i18n/plurals/fr.rb
@@ -1,0 +1,17 @@
+module NumbersAndWords
+  module I18n
+    module Plurals
+      module Fr
+        RULE = lambda do |n|
+           one_conditions(n) ? :one : :many
+        end
+
+        extend self
+
+        def one_conditions n
+          n % 10 == 1 && n % 100 != 11
+        end
+      end
+    end
+  end
+end

--- a/lib/numbers_and_words/strategies.rb
+++ b/lib/numbers_and_words/strategies.rb
@@ -1,5 +1,6 @@
 require 'numbers_and_words/strategies/base'
 require 'numbers_and_words/strategies/ru'
 require 'numbers_and_words/strategies/en'
+require 'numbers_and_words/strategies/fr'
 require 'numbers_and_words/strategies/ua'
 require 'numbers_and_words/strategies/tr'

--- a/lib/numbers_and_words/strategies/fr.rb
+++ b/lib/numbers_and_words/strategies/fr.rb
@@ -1,0 +1,79 @@
+module NumbersAndWords
+  module Strategies
+    class Fr < Base
+      include NumbersAndWords::TranslationsHelpers::Fr
+
+      attr_accessor :figures_in_previous_capacity
+
+      def convert figures
+        @figures = figures.reverse
+
+        @words = strings
+        @words.empty? ? zero : @words.reverse.join(' ')
+      end
+
+      private
+
+      def strings
+        if figures.capacity_count
+          complex_to_words
+        elsif figures.hundreds
+          simple_hundreds_to_words
+        elsif figures.tens or figures.ones
+          simple_to_words
+        else
+          []
+        end
+      end
+
+      def complex_to_words
+        words = []
+        figures.capacity_count.times do |capacity|
+          number_in_capacity_by_words = save_parent_figures do |parent_figures|
+            @figures = parent_figures.figures_array_in_capacity(capacity)
+            strings
+          end
+
+          unless number_in_capacity_by_words.empty?
+            if 0 < capacity
+              words.push translation_megs(capacity, figures.number_in_capacity(capacity))
+            end
+            unless 1 == capacity && number_in_capacity_by_words == [t(:ones)[1]]
+              words += number_in_capacity_by_words
+            end
+          end
+        end
+        words
+      end
+
+      def simple_hundreds_to_words
+        if simple_to_words.empty?
+          [translation_hundreds(figures.hundreds, true)]
+        else
+          simple_to_words + [translation_hundreds(figures.hundreds)]
+        end
+      end
+
+      def simple_to_words
+        if figures.teens
+          [translation_teens(figures.ones)]
+        elsif figures.tens
+          figures.ones ?
+            [translation_tens_with_ones(figures.tens_with_ones)] :
+            [translation_tens_alone(figures.tens)]
+        elsif figures.ones
+          [translation_ones(figures.ones)]
+        else
+          []
+        end
+      end
+
+      def save_parent_figures
+        parent_figures = @figures
+        result = yield(parent_figures)
+        @figures = parent_figures
+        result
+      end
+    end
+  end
+end

--- a/lib/numbers_and_words/translations_helpers.rb
+++ b/lib/numbers_and_words/translations_helpers.rb
@@ -1,4 +1,5 @@
 require 'numbers_and_words/translations_helpers/base'
 require 'numbers_and_words/translations_helpers/ru'
 require 'numbers_and_words/translations_helpers/en'
+require 'numbers_and_words/translations_helpers/fr'
 require 'numbers_and_words/translations_helpers/tr'

--- a/lib/numbers_and_words/translations_helpers/fr.rb
+++ b/lib/numbers_and_words/translations_helpers/fr.rb
@@ -1,0 +1,60 @@
+module NumbersAndWords
+  module TranslationsHelpers
+    module Fr
+      include NumbersAndWords::TranslationsHelpers::Base
+
+      private
+
+      def translation_teens number
+        t(:teens)[number]
+      end
+
+      def translation_tens_alone number
+        if number == 8
+          t(:eighty)
+        else
+          translation_tens number
+        end
+      end
+
+      def translation_tens number
+        t(:tens)[number]
+      end
+
+      def translation_ones number
+        t(:ones)[number]
+      end
+
+      def translation_tens_with_ones numbers
+        if [7, 9].include? numbers[1]
+          [translation_tens(numbers[1] - 1), translation_teens(numbers[0])].join '-'
+        else
+          union = numbers[0] == 1 ? ' et ' : '-'
+          [translation_tens(numbers[1]), translation_ones(numbers[0])].join union
+        end
+      end
+
+      def translation_hundreds number, pluralize = false
+        hundreds = t :hundreds, :count => pluralize ? number : 1
+
+        if number == 1
+          hundreds
+        else
+          [t(:ones)[number], hundreds].join ' '
+        end
+      end
+
+      def translation_mega capacity
+        t(:mega)[capacity]
+      end
+
+      def translation_megs capacity, number
+        t translation_mega(capacity), :count => number
+      end
+
+      def zero
+        t(:ones)[0]
+      end
+    end
+  end
+end

--- a/spec/numbers_and_words/array/fr_spec.rb
+++ b/spec/numbers_and_words/array/fr_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Array do
+  around(:each) { |example| I18n.with_locale(:fr) { example.run } }
+
+  describe '#to_words' do
+    context 'simple example' do
+      subject { [1, 2, 3] }
+      its(:to_words) { should == [ "un", "deux", "trois" ] }
+    end
+
+    context 'complex example' do
+      subject { [101, 21, 13] }
+      its(:to_words) { should == ["cent un", "vingt et un", "treize"] }
+    end
+  end
+end

--- a/spec/numbers_and_words/i18n/pluralization/fr_spec.rb
+++ b/spec/numbers_and_words/i18n/pluralization/fr_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe I18n, 'fr' do
+  before(:each) do
+    @hash = {}
+    %w(one many).each { |key| @hash[key.to_sym] = key }
+    @backend = I18n.backend
+  end
+
+  it "should pluralize correctly" do
+    @backend.send(:pluralize, :'fr', @hash, 1).should == 'one'
+    @backend.send(:pluralize, :'fr', @hash, 2).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 3).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 5).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 10).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 11).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 21).should == 'one'
+    @backend.send(:pluralize, :'fr', @hash, 29).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 131).should == 'one'
+    @backend.send(:pluralize, :'fr', @hash, 1.31).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 2.31).should == 'many'
+    @backend.send(:pluralize, :'fr', @hash, 3.31).should == 'many'
+  end
+end

--- a/spec/numbers_and_words/integer/fixture_examples/fr.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/fr.yml
@@ -1,0 +1,51 @@
+to_words:
+  ones:
+    0: zéro
+    1: un
+    9: neuf
+  teens:
+    10: dix
+    11: onze
+    19: dix-neuf
+    20: vingt
+    21: vingt et un
+    80: quatre-vingts
+    90: quatre-vingt-dix
+    99: quatre-vingt-dix-neuf
+  hundreds:
+    100: cent
+    101: cent un
+    111: cent onze
+    120: cent vingt
+    121: cent vingt et un
+    900: neuf cents
+    909: neuf cent neuf
+    919: neuf cent dix-neuf
+    990: neuf cent quatre-vingt-dix
+    999: neuf cent quatre-vingt-dix-neuf
+  thousands:
+    1000: mille
+    2000: deux mille
+    4000: quatre mille
+    5000: cinq mille
+    11000: onze mille
+    21000: vingt et un mille
+    999000: neuf cent quatre-vingt-dix-neuf mille
+    999999: neuf cent quatre-vingt-dix-neuf mille neuf cent quatre-vingt-dix-neuf
+  millions:
+    1000000: un million
+    2000000: deux millions
+    4000000: quatre millions
+    5000000: cinq millions
+    999000000: neuf cent quatre-vingt-dix-neuf millions
+    999000999: neuf cent quatre-vingt-dix-neuf millions neuf cent quatre-vingt-dix-neuf
+    999999000: neuf cent quatre-vingt-dix-neuf millions neuf cent quatre-vingt-dix-neuf mille
+    999999999: neuf cent quatre-vingt-dix-neuf millions neuf cent quatre-vingt-dix-neuf mille neuf cent quatre-vingt-dix-neuf
+  billions:
+    1174315110: un milliard cent soixante-quatorze millions trois cent quinze mille cent dix
+    1174315119: un milliard cent soixante-quatorze millions trois cent quinze mille cent dix-neuf
+    15174315119: quinze milliards cent soixante-quatorze millions trois cent quinze mille cent dix-neuf
+    35174315119: trente-cinq milliards cent soixante-quatorze millions trois cent quinze mille cent dix-neuf
+    935174315119: neuf cent trente-cinq milliards cent soixante-quatorze millions trois cent quinze mille cent dix-neuf
+  trillions:
+    2935174315119: deux billions neuf cent trente-cinq milliards cent soixante-quatorze millions trois cent quinze mille cent dix-neuf

--- a/spec/numbers_and_words/integer/fr_spec.rb
+++ b/spec/numbers_and_words/integer/fr_spec.rb
@@ -1,0 +1,10 @@
+# coding: utf-8
+require 'spec_helper'
+require 'numbers_and_words/integer/shared_examples/correct_fixture_examples'
+
+describe Integer do
+  around(:each) { |example| ::I18n.with_locale(:fr) { example.run } }
+
+  subject { fixture_examples }
+  it_behaves_like 'correct fixture examples'
+end


### PR DESCRIPTION
I couldn't find any such library with french language support, so I figured I would contribute french language support to the best one I found.

The numbering system used is the official one used in France and set by the "Décret n°61-501 du 3 mai 1961 relatif aux unités de mesure et au contrôle des instruments de mesure".
