### PR TITLE
Remove all warnings in gem. (ruby -w)

### DIFF
--- a/lib/numbers_and_words/i18n/initialization.rb
+++ b/lib/numbers_and_words/i18n/initialization.rb
@@ -3,8 +3,6 @@ module NumbersAndWords
     module Initialization
       extend self
 
-      attr_accessor :languages
-
       def init
         locale_files.each { |locale_file| ::I18n.load_path << locale_file}
         NumbersAndWords::I18n::Pluralization.init


### PR DESCRIPTION
This seems to be unused and actually generated this warning upon requiring numbers_and_words (in Ruby 1.9.3):

ruby-1.9.3-p327/gems/numbers_and_words-0.7.1/lib/numbers_and_words/i18n/initialization.rb:13: warning: method redefined; discarding old languages

This fix eliminates the warning.
