### PR TITLE
Add ordinal support for dutch (nl) locale

### DIFF
--- a/lib/numbers_and_words/i18n/locales/numbers.nl.yml
+++ b/lib/numbers_and_words/i18n/locales/numbers.nl.yml
@@ -4,4 +4,12 @@ nl:
     teens: [tien, elf, twaalf, dertien, veertien, vijftien, zestien, zeventien, achttien, negentien]
     tens: [nul, tien, twintig, dertig, veertig, vijftig, zestig, zeventig, tachtig, negentig]
     hundreds: honderd
+    thousands: duizend
     mega: [degenen, duizend, miljoen, miljard, biljoen, biljard, triljoen, triljard, septiljoen, octillion, noniljoen, decillion]
+    ordinal:
+      ones: [nulde, eerste, tweede, derde, vierde, vijfde, zesde, zevende, achtste, negende]
+      teens: [tiende, elfde, twaalfde, dertiende, veertiende, vijftiende, zestiende, zeventiende, achtiende, negentiende]
+      tens: [nulde, tiende, twintigste, dertigste, veertigste, vijftigste, zestigste, zeventigste, tachtigste, negentigste]
+      hundreds: honderdste
+      mega: [nulde, duizendste, miljoenste, miljardste, biljoenste, biljardste, triljoenste, triljardste, septiljoenste, octillionste, noniljoenste, decillionste]
+    micro: [_, tienden, honderden, duizenden, miljoensten, biljoensten, biljardsten, triljoensten, triljardsten, septiljoensten, octillionsten, noniljoensten, decillionsten]

--- a/lib/numbers_and_words/strategies/figures_converter/languages/nl.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/languages/nl.rb
@@ -19,6 +19,16 @@ module NumbersAndWords
               super
             end
           end
+
+          [:zero, :ones, :teens, :tens, :tens_with_ones, :hundreds, :megs].each do |method_name|
+            define_method(method_name) {
+              super({:prefix => maybe_ordinal(method_name)})
+            }
+          end
+
+          def maybe_ordinal type
+            @options.ordinal.result type
+          end
         end
       end
     end

--- a/lib/numbers_and_words/strategies/figures_converter/options.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/options.rb
@@ -3,6 +3,7 @@ require 'numbers_and_words/strategies/figures_converter/options/en_gb'
 require 'numbers_and_words/strategies/figures_converter/options/ru'
 require 'numbers_and_words/strategies/figures_converter/options/ua'
 require 'numbers_and_words/strategies/figures_converter/options/hu'
+require 'numbers_and_words/strategies/figures_converter/options/nl'
 
 module NumbersAndWords
   module Strategies

--- a/lib/numbers_and_words/strategies/figures_converter/options/nl.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/options/nl.rb
@@ -1,0 +1,1 @@
+require 'numbers_and_words/strategies/figures_converter/options/nl/ordinal'

--- a/lib/numbers_and_words/strategies/figures_converter/options/nl/ordinal.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/options/nl/ordinal.rb
@@ -2,10 +2,9 @@ module NumbersAndWords
   module Strategies
     module FiguresConverter
       module Options
-        module Hu
+        module Nl
           class Ordinal
             ZERO_TYPE = :zero
-            HUNDRED_TYPE = :hundreds
             MEGS_TYPE = :megs
 
             def initialize proxy, *args, &block
@@ -33,8 +32,7 @@ module NumbersAndWords
             end
 
             def simple_numbers_condition
-              current_capacity.nil? &&
-                (HUNDRED_TYPE != @type || (HUNDRED_TYPE == @type && simple_number_to_words.empty?))
+              current_capacity.nil?
             end
 
             def megs_numbers_condition

--- a/lib/numbers_and_words/translations/nl.rb
+++ b/lib/numbers_and_words/translations/nl.rb
@@ -4,11 +4,11 @@ module NumbersAndWords
       include NumbersAndWords::Translations::Families::Latin
 
       def tens_with_ones numbers, options = {}
-        [ones(numbers[0]), tens(numbers[1])].join 'en'
+        [ones(numbers[0]), tens(numbers[1], options)].join 'en'
       end
 
       def hundreds number, options = {}
-        1 == number ? t(:hundreds) : [t(:ones)[number], t(:hundreds)].join
+        1 == number ? t([options[:prefix], :hundreds].join('.')) : [t(:ones)[number], t([options[:prefix], :hundreds].join('.'))].join
       end
     end
   end

--- a/numbers_and_words.gemspec
+++ b/numbers_and_words.gemspec
@@ -119,6 +119,8 @@ Gem::Specification.new do |s|
     "lib/numbers_and_words/strategies/figures_converter/options/en_gb/remove_zero.rb",
     "lib/numbers_and_words/strategies/figures_converter/options/hu.rb",
     "lib/numbers_and_words/strategies/figures_converter/options/hu/ordinal.rb",
+    "lib/numbers_and_words/strategies/figures_converter/options/nl.rb",
+    "lib/numbers_and_words/strategies/figures_converter/options/nl/ordinal.rb",
     "lib/numbers_and_words/strategies/figures_converter/options/ru.rb",
     "lib/numbers_and_words/strategies/figures_converter/options/ru/gender.rb",
     "lib/numbers_and_words/strategies/figures_converter/options/ua.rb",

--- a/spec/numbers_and_words/integer/fixture_examples/nl.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/nl.yml
@@ -26,7 +26,7 @@ to_words:
     990: negenhonderdnegentig
     999: negenhonderdnegenennegentig
   thousands:
-    1000: éénduizend
+    1000: duizend
     2000: tweeduizend
     4000: vierduizend
     5000: vijfduizend
@@ -83,7 +83,7 @@ to_words:
     80: tachtigste
     90: negentigste
     100: honderdste
-    1000: éénduizendste
+    1000: duizendste
     1000000: één miljoenste
     1000000000: één miljardste
     1000000000000: één biljoenste

--- a/spec/numbers_and_words/integer/fixture_examples/nl.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/nl.yml
@@ -9,6 +9,7 @@ to_words:
     19: negentien
     20: twintig
     21: éénentwintig
+    42: tweeënveertig
     80: tachtig
     90: negentig
     99: negenennegentig
@@ -18,6 +19,7 @@ to_words:
     111: honderdelf
     120: honderdtwintig
     121: honderdéénentwintig
+    142: honderdtweeënveertig
     900: negenhonderd
     909: negenhonderdnegen
     919: negenhonderdnegentien
@@ -94,6 +96,7 @@ to_words:
     1000000000000000000000000000000000: één decillionste
     21: éénentwintigste
     42: tweeenveertigste
+    142: honderdtweeënveertigste
     4200: vierduizend tweehonderdste
     42000: tweeenveertigduizendste
     420000: vierhonderdtwintigduizendste

--- a/spec/numbers_and_words/integer/fixture_examples/nl.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/nl.yml
@@ -8,17 +8,17 @@ to_words:
     11: elf
     19: negentien
     20: twintig
-    21: éénentwintig
+    21: eenentwintig
     42: tweeënveertig
     80: tachtig
     90: negentig
     99: negenennegentig
   hundreds:
     100: honderd
-    101: honderdéén
+    101: honderdeen
     111: honderdelf
     120: honderdtwintig
-    121: honderdéénentwintig
+    121: honderdeenentwintig
     142: honderdtweeënveertig
     900: negenhonderd
     909: negenhonderdnegen
@@ -31,7 +31,7 @@ to_words:
     4000: vierduizend
     5000: vijfduizend
     11000: elfduizend
-    21000: éénentwintigduizend
+    21000: eenentwintigduizend
     999000: negenhonderdnegenennegentigduizend
     999999: negenhonderdnegenennegentigduizend negenhonderdnegenennegentig
   millions:
@@ -94,9 +94,9 @@ to_words:
     1000000000000000000000000000: één octillionste
     1000000000000000000000000000000: één noniljoenste
     1000000000000000000000000000000000: één decillionste
-    21: éénentwintigste
+    21: eenentwintigste
     42: tweeenveertigste
-    131: honderdéénendertigste
+    131: honderdeenendertigste
     142: honderdtweeënveertigste
     4200: vierduizend tweehonderdste
     4256: vierduizend tweehonderdzesenvijftigste

--- a/spec/numbers_and_words/integer/fixture_examples/nl.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/nl.yml
@@ -49,3 +49,53 @@ to_words:
     935174315119: negenhonderdvijfendertig miljard honderdvierenzeventig miljoen driehonderdvijftienduizend honderdnegentien
   trillions:
     2935174315119: twee biljoen negenhonderdvijfendertig miljard honderdvierenzeventig miljoen driehonderdvijftienduizend honderdnegentien
+  ordinals:
+    options:
+      :ordinal: true
+    0: nulde
+    1: eerste
+    2: tweede
+    3: derde
+    4: vierde
+    5: vijfde
+    6: zesde
+    7: zevende
+    8: achtste
+    9: negende
+    10: tiende
+    11: elfde
+    12: twaalfde
+    13: dertiende
+    14: veertiende
+    15: vijftiende
+    16: zestiende
+    17: zeventiende
+    18: achtiende
+    19: negentiende
+    20: twintigste
+    30: dertigste
+    40: veertigste
+    50: vijftigste
+    60: zestigste
+    70: zeventigste
+    80: tachtigste
+    90: negentigste
+    100: honderdste
+    1000: éénduizendste
+    1000000: één miljoenste
+    1000000000: één miljardste
+    1000000000000: één biljoenste
+    1000000000000000: één biljardste
+    1000000000000000000: één triljoenste
+    1000000000000000000000: één triljardste
+    1000000000000000000000000: één septiljoenste
+    1000000000000000000000000000: één octillionste
+    1000000000000000000000000000000: één noniljoenste
+    1000000000000000000000000000000000: één decillionste
+    21: éénentwintigste
+    42: tweeenveertigste
+    4200: vierduizend tweehonderdste
+    42000: tweeenveertigduizendste
+    420000: vierhonderdtwintigduizendste
+    4200000: vier miljoen tweehonderdduizendste
+    42000000: tweeenveertig miljoenste

--- a/spec/numbers_and_words/integer/fixture_examples/nl.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/nl.yml
@@ -96,8 +96,10 @@ to_words:
     1000000000000000000000000000000000: één decillionste
     21: éénentwintigste
     42: tweeenveertigste
+    131: honderdéénendertigste
     142: honderdtweeënveertigste
     4200: vierduizend tweehonderdste
+    4256: vierduizend tweehonderdzesenvijftigste
     42000: tweeenveertigduizendste
     420000: vierhonderdtwintigduizendste
     4200000: vier miljoen tweehonderdduizendste


### PR DESCRIPTION
It is not perfect yet, but it is a start.

I did not know exactly how to fix these problems:
42nd = 'tweeenveertigste', but should be 'tweeënveertigste' (this goes wrong because 42 = 'tweeenveertig' is also wrong)
131st = 'honderdsteéénendertigste', but should be 'honderdéénendertigste'
133rd = 'honderdstedrieendertigste', but should be 'honderddrieëndertigste'
1000st = 'éénduizendste', but should be 'duizendste' (this goes wrong because 1000 = 'éénduizend' is also wrong)
4256th = 'vierduizend tweehonderdzesenvijftigste', but should be 'vierduizend tweehonderdzesenvijftigste'

For some correct examples (only in Dutch) see: http://woordenlijst.org/leidraad/6/9