### PR TITLE
Fix #119 - pluralization rules for es

### DIFF
--- a/lib/numbers_and_words/i18n/plurals/es.rb
+++ b/lib/numbers_and_words/i18n/plurals/es.rb
@@ -5,6 +5,12 @@ module NumbersAndWords
         include Fr
 
         RULE = Fr::RULE
+
+        extend self
+
+        def one_conditions(n)
+          n == 1
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #119, only for Spanish, as I'm not sure about French and others.