### PR TITLE
Fix ES typo twenty-one something

### DIFF
--- a/lib/numbers_and_words/i18n/locales/numbers.es.yml
+++ b/lib/numbers_and_words/i18n/locales/numbers.es.yml
@@ -2,6 +2,7 @@ es:
   numbers:
     one: un
     ones: [cero, uno, dos, tres, cuatro, cinco, seis, siete, ocho, nueve]
+    one_twenties: ún
     ones_twenties: [_, uno, dós, trés, cuatro, cinco, séis, siete, ocho, nueve]
 
     teens: [diez, once, doce, trece, catorce, quince, dieciséis, diecisiete, dieciocho, diecinueve]
@@ -13,3 +14,4 @@ es:
 
     mega: [_, mil, millón, mil millones, billón, mil billones, trillón, mil trillones, cuatrillón, mil cuatrillones, quintillón, mil quintillones]
     megas: [_, mil, millones, mil millones, billones, mil billones, trillones, mil trillones, cuatrillones, mil cuatrillones, quintillones, mil quintillones]
+    union: y

--- a/lib/numbers_and_words/strategies/figures_converter/languages/es.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/languages/es.rb
@@ -11,33 +11,39 @@ module NumbersAndWords
             words.push megs(capacity_words) unless capacity_words.empty?
 
             if 0 < @current_capacity
-              # eg 1000000 should be "un millón" not "uno millón"
-              #    501000 should be "quinientos un mil" not "quinientos uno mil"
-              #    1000 should be "mil" not "uno mil"
-              # so we replace "uno" with "un" throughout or delete it if that is the case
-
-              capacity_words = capacity_words.map { |word|
-                word.gsub(@translations.ones(1), @translations.one) unless is_a_thousand? and is_a_one?
-              }.compact
+              capacity_words = capacity_words.map do |word|
+                if twenty_one?
+                  word.gsub(@translations.ones(1), @translations.one_twenties)
+                elsif !thousand? || !one?
+                  word.gsub(@translations.ones(1), @translations.one)
+                end
+              end.compact
             end
 
             words + capacity_words
           end
 
-          def is_a_one?
+          def hundreds
+            super({ is_hundred: (figures[1, 2] == [0, 1] &&
+                                 simple_number_to_words.empty?) })
+          end
+
+          def megs(capacity_words)
+            super({ is_one: capacity_words == [@translations.ones(1)] })
+          end
+
+          private
+
+          def one?
             [translations.ones(1)] == words_in_capacity(@current_capacity)
           end
 
-          def is_a_thousand?
+          def thousand?
             @current_capacity.odd?
           end
 
-          def hundreds
-            super({:is_hundred => (figures[1,2] == [0,1] && simple_number_to_words.empty?)})
-          end
-
-          def megs capacity_words
-            super({:is_one => capacity_words == [@translations.ones(1)]})
+          def twenty_one?
+            figures.reverse[0..1] == [2, 1]
           end
         end
       end

--- a/lib/numbers_and_words/translations/es.rb
+++ b/lib/numbers_and_words/translations/es.rb
@@ -5,35 +5,39 @@ module NumbersAndWords
 
       TENS_CASE = 2
 
-      def one options = {}
+      def one
         t(:one)
       end
 
-      def ones number, options = {}
+      def ones(number, _options = {})
         t(:ones)[number]
       end
 
-      def ones_twenties number, options = {}
+      def one_twenties
+        t(:one_twenties)
+      end
+
+      def ones_twenties(number)
         t(:ones_twenties)[number]
       end
 
-      def tens numbers, options = {}
+      def tens(numbers, options = {})
         options[:alone] = true if options[:alone].nil?
         (numbers == TENS_CASE && options[:alone]) ? t(:twenty) : super(numbers)
       end
 
-      def tens_with_ones numbers, options = {}
-        inter = numbers[1] == TENS_CASE ? "" : " y "
+      def tens_with_ones(numbers, _options = {})
+        union = numbers[1] == TENS_CASE ? '' : " #{t(:union)} "
         ones_number = numbers[1] == TENS_CASE ? ones_twenties(numbers[0]) : ones(numbers[0])
-        [tens(numbers[1], :alone => false), ones_number].join inter
+        [tens(numbers[1], alone: false), union, ones_number].join
       end
 
-      def hundreds number, options = {}
+      def hundreds(number, options = {})
         options[:is_hundred] = false if options[:is_hundred].nil?
         options[:is_hundred] ? t(:one_hundred) : t(:hundreds)[number - 1]
       end
 
-      def megs capacity, options = {}
+      def megs(capacity, options = {})
         options[:is_one] = false if options[:is_one].nil?
         options[:is_one] ? t(:mega)[capacity] : t(:megas)[capacity]
       end

--- a/spec/numbers_and_words/integer/fixture_examples/es.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/es.yml
@@ -33,7 +33,8 @@ to_words:
     4000: cuatro mil
     5000: cinco mil
     11000: once mil
-    21000: veintiun mil
+    21000: veintiún mil
+    21021: veintiún mil veintiuno
     999000: novecientos noventa y nueve mil
     999999: novecientos noventa y nueve mil novecientos noventa y nueve
   millions:


### PR DESCRIPTION
This should fix a typo in Spanish, where  _twenty-one something_ (i.e. _veintiún mil_) was missing an accent.

The ES code could get some :heart: as it is getting harder to debug. Fortunately, the tests are OK.
