### PR TITLE
Swedish - grammar and spelling corrections

### DIFF
--- a/lib/numbers_and_words/translations/se.rb
+++ b/lib/numbers_and_words/translations/se.rb
@@ -4,7 +4,7 @@ module NumbersAndWords
       include NumbersAndWords::Translations::Families::Latin
 
       def tens_with_ones(numbers, _options = {})
-        super numbers, separator: '-'
+        super numbers, separator: ''
       end
     end
   end

--- a/spec/numbers_and_words/array/fixture_examples/se.yml
+++ b/spec/numbers_and_words/array/fixture_examples/se.yml
@@ -5,7 +5,7 @@ to_words:
       - 2
       - 3
     :
-      - en
+      - ett
       - två
       - tre
   complex_example:
@@ -14,6 +14,6 @@ to_words:
       - 21
       - 13
     :
-      - en hundra en
-      - tjugo-en
+      - etthundraett
+      - tjugoett
       - tretton

--- a/spec/numbers_and_words/integer/fixture_examples/se.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/se.yml
@@ -1,51 +1,51 @@
 to_words:
   ones:
     0: noll
-    1: en
+    1: ett
     9: nio
   teens:
     10: tio
     11: elva
     19: nitton
     20: tjugo
-    21: tjugo-en
+    21: tjugoett
     80: åttio
     90: nittio
-    99: nittio-nio
+    99: nittionio
   hundreds:
-    100: en hundra
-    101: en hundra en
-    111: en hundra elva
-    120: en hundra tjugo
-    121: en hundra tjugo-en
-    900: nio hundra
-    909: nio hundra nio
-    919: nio hundra nitton
-    990: nio hundra nittio
-    999: nio hundra nittio-nio
+    100: etthundra
+    101: etthundraett
+    111: etthundraelva
+    120: etthundratjugo
+    121: etthundratjugoett
+    900: niohundra
+    909: niohundranio
+    919: niohundranitton
+    990: niohundranittio
+    999: niohundranittionio
   thousands:
-    1000: en tusen
-    2000: två tusen
-    4000: fyra tusen
-    5000: fem tusen
-    11000: elva tusen
-    21000: tjugo-en tusen
-    999000: nio hundra nittio-nio tusen
-    999999: nio hundra nittio-nio tusen nio hundra nittio-nio
+    1000: etttusen
+    2000: tvåtusen
+    4000: fyratusen
+    5000: femtusen
+    11000: elvatusen
+    21000: tjugoett tusen
+    999000: niohundranittionio tusen
+    999999: niohundranittionio tusen niohundranittionio
   millions:
-    1000000: en miljoner
+    1000000: en miljon
     2000000: två miljoner
     4000000: fyra miljoner
     5000000: fem miljoner
-    999000000: nio hundra nittio-nio miljoner
-    999000999: nio hundra nittio-nio miljoner nio hundra nittio-nio
-    999999000: nio hundra nittio-nio miljoner nio hundra nittio-nio tusen
-    999999999: nio hundra nittio-nio miljoner nio hundra nittio-nio tusen nio hundra nittio-nio
+    999000000: niohundranittionio miljoner
+    999000999: niohundranittionio miljoner niohundranittionio
+    999999000: niohundranittionio miljoner niohundranittionio tusen
+    999999999: niohundranittionio miljoner niohundranittionio tusen niohundranittionio
   billions:
-    1174315110: en miljarder en hundra sjuttio-fyra miljoner tre hundra femton tusen en hundra tio
-    1174315119: en miljarder en hundra sjuttio-fyra miljoner tre hundra femton tusen en hundra nitton
-    15174315119: femton miljarder en hundra sjuttio-fyra miljoner tre hundra femton tusen en hundra nitton
-    35174315119: trettio-fem miljarder en hundra sjuttio-fyra miljoner tre hundra femton tusen en hundra nitton
-    935174315119: nio hundra trettio-fem miljarder en hundra sjuttio-fyra miljoner tre hundra femton tusen en hundra nitton
+    1174315110: en miljard etthundrasjuttiofyra miljoner trehundrafemton tusen etthundratio
+    1174315119: en miljard etthundrasjuttiofyra miljoner trehundrafemton tusen etthundranitton
+    15174315119: femton miljarder etthundrasjuttiofyra miljoner trehundrafemton tusen etthundranitton
+    35174315119: trettiofem miljarder etthundrasjuttiofyra miljoner trehundrafemton tusen etthundranitton
+    935174315119: niohundratrettiofem miljarder etthundrasjuttiofyra miljoner trehundrafemton tusen etthundranitton
   trillions:
-    2935174315119: två biljoner nio hundra trettio-fem miljarder en hundra sjuttio-fyra miljoner tre hundra femton tusen en hundra nitton
+    2935174315119: två biljoner niohundratrettiofem miljarder etthundrasjuttiofyra miljoner trehundrafemton tusen etthundranitton


### PR DESCRIPTION
Numeral names in Swedish is written together as one word, except for names above "miljon" (million) and if the number is 21-999 (except ending in 0) preceding "tusen" (thousand). Also for 1, "ett" is often used; when preceding "hundra" (hundred) and "tusen" (thousand), "ett" is always used. Before "miljon" (million) and larger names, "en" is used instead. – So "21" and "100" would be "tjugoett" and "etthundra" instead of "tjugo-ett" and "en hundra".