### PR TITLE
Avoid adding all array extensions to the standard Array class

### DIFF
--- a/lib/numbers_and_words/helper_classes/figures_array.rb
+++ b/lib/numbers_and_words/helper_classes/figures_array.rb
@@ -4,13 +4,17 @@ require 'numbers_and_words/helper_classes/array_extensions/helpers'
 
 module NumbersAndWords
   class FiguresArray < Array
-    Array.include ArrayExtensions::Helpers
+    include ArrayExtensions::Helpers
 
     def to_words(options = {})
       local_language { Strategies.figures_converter.new(self, options).run }
     end
 
     def reverse
+      super.to_figures
+    end
+
+    def figures_array_in_capacity(capacity)
       super.to_figures
     end
 


### PR DESCRIPTION
The pull request that added support for Ruby 3.0 (#178) made the entire
ArrayExtensions::Helpers module be included in the Array class. This pull
request reverts that change and instead overrides #figures_array_in_capacity so
it returns the correct class instead.
 ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to kslazarev:master from mvz:avoid-full-array-monkey-patch

Write a message for this pull request. The first block
of text is the title and the rest is the description.