### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
     - 'numbers_and_words.gemspec'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.5
   - 2.6
   - 2.7
   - 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
   * Add support for Ruby 3.1. \[[#187](https://github.com/kslazarev/numbers_and_words/pull/187)\]
+  * Drop support for Ruby 2.5. \[[#180](https://github.com/kslazarev/numbers_and_words/pull/180)\]
   * Your contribution here.
 
 ## 0.11.11 (July 5, 2021)

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ Jeweler::Tasks.new do |gem|
   gem.version = NumbersAndWords::VERSION
   gem.authors = ['Kirill Lazarev']
   gem.files = Dir.glob('lib/**/*')
-  gem.required_ruby_version = '>= 2.5.0'
+  gem.required_ruby_version = '>= 2.6.0'
 end
 
 Jeweler::RubygemsDotOrgTasks.new

--- a/lib/numbers_and_words/i18n/plurals/plurals.rb
+++ b/lib/numbers_and_words/i18n/plurals/plurals.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-NumbersAndWords::I18n::Pluralization.languages.map do |language|
+NumbersAndWords::I18n::Pluralization.languages.to_h do |language|
   [language.to_sym, {
     i18n: {
       plural: {
@@ -8,4 +8,4 @@ NumbersAndWords::I18n::Pluralization.languages.map do |language|
       }
     }
   }]
-end.to_h
+end

--- a/lib/numbers_and_words/strategies/figures_converter/languages/de.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/languages/de.rb
@@ -39,8 +39,8 @@ module NumbersAndWords
           private
 
           def print_megs
-            complex_part[1..-1].map do |el|
-              [el[1..-1].to_a.reverse.join, el.first].join(' ')
+            complex_part[1..].map do |el|
+              [el[1..].to_a.reverse.join, el.first].join(' ')
             end.reject(&:empty?).reverse.join(' ')
           end
 


### PR DESCRIPTION
- Ruby 2.5 is EOL
- Fix some RuboCop suggestions
