### PR TITLE
French: corrects a few cases concerning plurals (involving 80/100) an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   * Add support for Ruby 3.4. \[[#204](https://github.com/kslazarev/numbers_and_words/pull/204)\]
   * Your contribution here.
 
+### Bugs
+  * Fix a few cases in French concerning plurals and union word (mainly 71 and 81). \[[#203](https://github.com/kslazarev/numbers_and_words/pull/203)\]
+
 ## 1.0.0 (October 17, 2024)
 
 ### Features

--- a/README.rdoc
+++ b/README.rdoc
@@ -9,7 +9,7 @@ Spell out numbers in several languages using the I18n gem.
 
 Перевод чисел в слова при помощи библиотеки I18n.
 
-Converti les nombres en lettres en utilisant la librairie I18n.
+Convertit les nombres en lettres en utilisant la librairie I18n.
 
 Számok betűvel írva az I18n könyvtár segítségével.
 

--- a/lib/numbers_and_words/strategies/figures_converter/languages/fr.rb
+++ b/lib/numbers_and_words/strategies/figures_converter/languages/fr.rb
@@ -14,7 +14,11 @@ module NumbersAndWords
           end
 
           def hundreds
-            super({ pluralize: simple_number_to_words.empty? })
+            super({ pluralize: simple_number_to_words.empty? && (@parent_figures.nil? || @parent_figures.size == 3) })
+          end
+
+          def tens
+            super({ alone: @current_capacity&.positive? ? false : nil })
           end
 
           def megs

--- a/lib/numbers_and_words/translations/fr.rb
+++ b/lib/numbers_and_words/translations/fr.rb
@@ -15,17 +15,21 @@ module NumbersAndWords
       end
 
       def tens_with_teens(numbers)
-        separator = numbers[1] == 7 && numbers[0] == 1 ? "-#{union}-" : '-'
-        [tens(numbers[1] - 1, alone: false), teens(numbers)].join(separator)
+        number_ones, number_tens = numbers.first(2)
+        separator = number_tens == 7 && number_ones == 1 ? "-#{union}-" : '-'
+        [tens(number_tens - 1, alone: false), teens(numbers)].join(separator)
       end
 
       def tens_with_ones(numbers, options = {})
-        return tens_with_teens(numbers) if [7, 9].include? numbers[1]
+        number_ones, number_tens = numbers
+        return tens_with_teens(numbers) if [7, 9].include?(number_tens)
 
-        separator = numbers[0] == 1 && numbers[1] != 8 ? " #{union} " : '-'
-        return [tens(numbers[1], alone: false), ones(numbers[0], options)].join separator || ' ' if numbers[1] == 8
-
-        super(numbers, options.merge(separator:))
+        separator = number_ones == 1 && number_tens != 8 ? " #{union} " : '-'
+        if number_tens == 8
+          [tens(number_tens, alone: false), ones(number_ones, options)].join(separator)
+        else
+          super(numbers, options.merge(separator:))
+        end
       end
 
       def hundreds(number, options = {})

--- a/lib/numbers_and_words/translations/fr.rb
+++ b/lib/numbers_and_words/translations/fr.rb
@@ -14,10 +14,17 @@ module NumbersAndWords
         super
       end
 
-      def tens_with_ones(numbers, options = {})
-        return [tens(numbers[1] - 1, alone: false), teens(numbers)].join('-') if [7, 9].include? numbers[1]
+      def tens_with_teens(numbers)
+        separator = numbers[1] == 7 && numbers[0] == 1 ? "-#{union}-" : '-'
+        [tens(numbers[1] - 1, alone: false), teens(numbers)].join(separator)
+      end
 
-        separator = numbers[0] == 1 ? " #{union} " : '-'
+      def tens_with_ones(numbers, options = {})
+        return tens_with_teens(numbers) if [7, 9].include? numbers[1]
+
+        separator = numbers[0] == 1 && numbers[1] != 8 ? " #{union} " : '-'
+        return [tens(numbers[1], alone: false), ones(numbers[0], options)].join separator || ' ' if numbers[1] == 8
+
         super(numbers, options.merge(separator:))
       end
 

--- a/spec/numbers_and_words/integer/fixture_examples/fr.yml
+++ b/spec/numbers_and_words/integer/fixture_examples/fr.yml
@@ -9,8 +9,16 @@ to_words:
     19: dix-neuf
     20: vingt
     21: vingt et un
+    70: soixante-dix
+    71: soixante-et-onze
+    72: soixante-douze
+    79: soixante-dix-neuf
     80: quatre-vingts
+    81: quatre-vingt-un
+    82: quatre-vingt-deux
     90: quatre-vingt-dix
+    91: quatre-vingt-onze
+    92: quatre-vingt-douze
     99: quatre-vingt-dix-neuf
   hundreds:
     100: cent
@@ -21,6 +29,7 @@ to_words:
     900: neuf cents
     909: neuf cent neuf
     919: neuf cent dix-neuf
+    980: neuf cent quatre-vingts
     990: neuf cent quatre-vingt-dix
     999: neuf cent quatre-vingt-dix-neuf
   thousands:
@@ -30,6 +39,8 @@ to_words:
     5000: cinq mille
     11000: onze mille
     21000: vingt et un mille
+    80000: quatre-vingt mille
+    200000: deux cent mille
     999000: neuf cent quatre-vingt-dix-neuf mille
     999999: neuf cent quatre-vingt-dix-neuf mille neuf cent quatre-vingt-dix-neuf
   millions:
@@ -38,6 +49,8 @@ to_words:
     4000000: quatre millions
     5000000: cinq millions
     21000000: vingt et un millions
+    80000000: quatre-vingt millions
+    200000000: deux cent millions
     999000000: neuf cent quatre-vingt-dix-neuf millions
     999000999: neuf cent quatre-vingt-dix-neuf millions neuf cent quatre-vingt-dix-neuf
     999999000: neuf cent quatre-vingt-dix-neuf millions neuf cent quatre-vingt-dix-neuf mille


### PR DESCRIPTION
Hello.
I discovered a few cases that were not handled correctly in French, in my opinion.

Examples:
(current incorrect spelling -> correct spelling)
* 71: soixante-onze -> soixante-et-onze
* 81: quatre-vingts et un -> quatre-vingt-un
* 82: quatre-vingts-deux -> quatre-vingt-deux
  (same for 83 up to 89)
* 80000: quatre-vingts mille -> quatre-vingt mille
* 200000: deux cents mille -> deux cent mille
* 80000000: quatre-vingts millions -> quatre-vingt millions
* 200000000: deux cents millions -> deux cent millions

My reference online tool to check number spelling is: https://leconjugueur.lefigaro.fr/frnombre.php

I take the liberty to mention some former french contributors, so they can share their opinion, if the proposed changes above seem relevant or not to them.
@fakenine @Startouf @AntoineBecquet 

This commit adds the mentioned numbers to the test list, and attempts to fix the issue.

Note: I'm not 100% confident with the test of the "number loneliness", in lib/numbers_and_words/strategies/figures_converter/languages/fr.rb. There is probably a better way for doing it, feel free to adapt.
