### PR TITLE
Add support for Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - 3.1
           - 3.2
           - 3.3
+          - 3.4
           - jruby
           - head
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.7
-  - 3.0
   - 3.1
   - 3.2
+  - 3.3
+  - 3.4
   - jruby
   - head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1 (Next)
 
 ### Features
+  * Add support for Ruby 3.4. \[[#204](https://github.com/kslazarev/numbers_and_words/pull/204)\]
   * Your contribution here.
 
 ## 1.0.0 (October 17, 2024)

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'i18n', '<= 2'
 
 group :development do
   gem 'jeweler', '~> 2'
+  gem 'ostruct', '~> 0'
   gem 'rake', '~> 12'
 end
 


### PR DESCRIPTION
While here, manually add 'ostruct' as a required gem in the development group.

Ref: https://www.ruby-lang.org/en/downloads/branches/