### PR TITLE
Appease RuboCop

### DIFF
--- a/lib/numbers_and_words/i18n.rb
+++ b/lib/numbers_and_words/i18n.rb
@@ -8,7 +8,7 @@ module NumbersAndWords
     module_function
 
     def languages
-      @languages ||= (locale_files.map { |path| path.split(%r{[/.]})[-2].to_sym })
+      @languages ||= locale_files.map { |path| path.split(%r{[/.]})[-2].to_sym }
     end
 
     def local_language(locale = ::I18n.locale)

--- a/lib/numbers_and_words/translations/de.rb
+++ b/lib/numbers_and_words/translations/de.rb
@@ -4,6 +4,7 @@ module NumbersAndWords
   module Translations
     class De < Base
       include NumbersAndWords::Translations::Families::Base
+
       DEFAULT_POSTFIX = :combine
 
       def ones(number, options = {})

--- a/lib/numbers_and_words/translations/ka.rb
+++ b/lib/numbers_and_words/translations/ka.rb
@@ -4,6 +4,7 @@ module NumbersAndWords
   module Translations
     class Ka < Base
       include NumbersAndWords::Translations::Families::Latin
+
       TENS_VIGESIMAL_RANGES = [
         {
           range: Range.new(0, 4, true),

--- a/lib/numbers_and_words/translations/vi.rb
+++ b/lib/numbers_and_words/translations/vi.rb
@@ -5,6 +5,7 @@ module NumbersAndWords
     class Vi < Base
       include NumbersAndWords::Translations::Families::Latin
       include NumbersAndWords::Translations::Extensions::FractionSignificance
+
       def ones_of_tens(number, options = {})
         return t('units.tens.one') if number == 1
         return t('units.tens.five') if number == 5


### PR DESCRIPTION
- Style/RedundantParentheses: Don't use parentheses around a method call.
- Layout/EmptyLinesAfterModuleInclusion: Add an empty line after module inclusion.